### PR TITLE
Enable writing to PWM fans on the B550 Taichi

### DIFF
--- a/nct6683.c
+++ b/nct6683.c
@@ -235,6 +235,8 @@ struct customer_family_matcher {
 static const struct customer_family_matcher customer_family_table[] = {
 	CUSTOMER_MATCHES_DMI_BOARD("ASRock", "B550 Taichi Razer Edition",
 				   family_asrock_writable_pwm),
+	CUSTOMER_MATCHES_DMI_BOARD("ASRock", "B550 Taichi",
+				   family_asrock_writable_pwm),
 	CUSTOMER_MATCHES_DMI_BOARD("ASRock", "B650I Lightning WiFi",
 				   family_asrock_writable_pwm),
 	CUSTOMER_MATCHES_DMI_BOARD("ASRock", "A620I Lightning WiFi",


### PR DESCRIPTION
I can confirm this also appears to work just fine on the standard, non-Razer-Edition B550 Taichi.