### PR TITLE
refresh pwm enable mask from hardware before write

### DIFF
--- a/nct6683.c
+++ b/nct6683.c
@@ -1045,15 +1045,16 @@ store_pwm_enable(struct device *dev, struct device_attribute *attr,
 	if (kstrtoul(buf, 10, &val) || (val != 0 && val != 1))
 		return -EINVAL;
 
-	pwm_enable = data->pwm_enable;
 	bitmask = 1 << index;
+
+	mutex_lock(&data->update_lock);
+	pwm_enable = nct6683_read(data, NCT6683_REG_FAN_CTRL_MODE);
 	if (val == 1)
 		pwm_enable = pwm_enable | bitmask;
 	else
 		pwm_enable = pwm_enable & ~bitmask;
-
-	mutex_lock(&data->update_lock);
 	nct6683_write(data, NCT6683_REG_FAN_CTRL_MODE, pwm_enable);
+	data->pwm_enable = pwm_enable;
 	mutex_unlock(&data->update_lock);
 
 	return count;


### PR DESCRIPTION
Hey,

I noticed an issue with this module that has been bothering me for month now. I own a Asrock B650I Lightning Wifi Board. I have three fans installed in my system, one on the cpu and two as case fans. Whenever I restarted the system, two of the fans would run very loud while the third successfully handed over control to coolercontrol, which I configured for a more silent profile.

Upon investigation I noticed that the pwm control is not configured for the loud fans, e.g. pwm_enable sysfs flag is 0 for the loud fans. This is consistently reproducible.
I sent out codex with gpt5.4 over the driver and it found a fix for the problem within a few minutes given my already narrow diagnosis. I cleaned up the rather large diff it produced to what I consider the minimal required changes to fix the bug.

The fix essentially just makes sure to read the current state of pwm_enable before each execution of `store_pwm_enable()`, so that a previous execution does not mess up the bitmask configuration. As a result, a later write can overwrite bits that were set by an earlier write, so effectivly only the last updated value remains (exactly the behaviour I observed).

On my system, this fixes the startup behavior and all three fans are correctly set for manual/PWM control after a reboot.

Let me know what you think. 
Alex